### PR TITLE
Fix buffer overflow and -Wreorder warnings

### DIFF
--- a/NXDNGateway/NXDNNetwork.cpp
+++ b/NXDNGateway/NXDNNetwork.cpp
@@ -49,7 +49,7 @@ bool CNXDNNetwork::writeData(const unsigned char* data, unsigned int length, uns
 	assert(length > 0U);
 	assert(port > 0U);
 
-	unsigned char buffer[20U];
+	unsigned char buffer[43U];
 
 	buffer[0U] = 'N';
 	buffer[1U] = 'X';

--- a/NXDNGateway/Voice.cpp
+++ b/NXDNGateway/Voice.cpp
@@ -53,9 +53,9 @@ m_timer(1000U, 1U),
 m_stopWatch(),
 m_sent(0U),
 m_ambe(NULL),
-m_positions(),
 m_voiceData(NULL),
-m_voiceLength(0U)
+m_voiceLength(0U),
+m_positions()
 {
 #if defined(_WIN32) || defined(_WIN64)
 	m_indxFile = directory + "\\" + language + ".indx";


### PR DESCRIPTION
Compiler messages were:

```
In file included from /usr/include/string.h:635:0,
                 from /usr/include/c++/5/cstring:42,
                 from NXDNNetwork.cpp:25:
In function ‘void* memcpy(void*, const void*, size_t)’,
    inlined from ‘bool CNXDNNetwork::writeData(const unsigned char*, unsigned int, short unsigned int, short unsigned int, bool, const in_ad
dr&, unsigned int)’ at NXDNNetwork.cpp:74:35:
/usr/include/i386-linux-gnu/bits/string3.h:53:71: warning: call to void* __builtin___memcpy_chk(void*, const void*, unsigned int, unsigned i
nt) will always overflow destination buffer
   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
                                                                       ^
```

and

```
Voice.h: In constructor ‘CVoice::CVoice(const string&, const string&, unsigned int)’:
Voice.h:65:47: warning: ‘CVoice::m_positions’ will be initialized after [-Wreorder]
  std::unordered_map<std::string, CPositions*> m_positions;
                                               ^
Voice.h:63:41: warning:   ‘unsigned char* CVoice::m_voiceData’ [-Wreorder]
  unsigned char*                         m_voiceData;
                                         ^
Voice.cpp:47:1: warning:   when initialized here [-Wreorder]
 CVoice::CVoice(const std::string& directory, const std::string& language, unsigned int srcId) :
 ^
```