### PR TITLE
Hosts Update

### DIFF
--- a/NXDNGateway/NXDNHosts.txt
+++ b/NXDNGateway/NXDNHosts.txt
@@ -63,8 +63,8 @@
 # Rhode Island Digital Link, 31444
 31444	18.219.32.21	41400
 
-# DMR Link?, 31665
-31665	nxdn.alecwasserman.com	41400
+# TGIF Network, 31665
+31665	tgif.network	41400
 
 # Pi-Star NXDN Reflector, 31672
 31672	nxdn-31672.pistar.uk	41400


### PR DESCRIPTION
Update Hosts IP address for TGIF 31665 to tgif.network