### PR TITLE
Re-open UDP socket on ENOTSOCK error.

### DIFF
--- a/NXDNGateway/UDPSocket.cpp
+++ b/NXDNGateway/UDPSocket.cpp
@@ -206,7 +206,14 @@ int CUDPSocket::read(unsigned char* buffer, unsigned int length, in_addr& addres
 		LogError("Error returned from recvfrom, err: %lu", ::GetLastError());
 #else
 		LogError("Error returned from recvfrom, err: %d", errno);
+
+		if ((len == -1) && (errno == ENOTSOCK)) {
+			LogInfo("Re-opening UDP port on %u", m_port);
+			close();
+			open();
+		}
 #endif
+
 		return -1;
 	}
 


### PR DESCRIPTION
Avoids to fill up the log with error 88.
Just like in the pending YSFClients PR.