### PR TITLE
Make IPV4 as a fallback, avoids open() failure (errno EAFNOSUPPORT, RPi).

### DIFF
--- a/NXDNGateway/NXDNNetwork.cpp
+++ b/NXDNGateway/NXDNNetwork.cpp
@@ -43,11 +43,11 @@ bool CNXDNNetwork::open()
 {
 	LogInfo("Opening NXDN network connection");
 
-	bool ret = m_socket.open(0, PF_INET, "", m_port);
-	if (!ret)
-		return false;
+	bool ret = m_socket.open(0, PF_INET6, "", m_port);
+	if (ret)
+		return true;
 
-	return m_socket.open(1, PF_INET6, "", m_port);
+	return m_socket.open(1, PF_INET, "", m_port);
 }
 
 bool CNXDNNetwork::writeData(const unsigned char* data, unsigned int length, unsigned short srcId, unsigned short dstId, bool grp, const sockaddr_storage& addr, unsigned int addrLen)


### PR DESCRIPTION
Since the last change, it fails to create the IPV6 socket for NXDNNetwork.
Same problem with P25Gateway (PR raised).