### PR TITLE
Add new remote command:

### DIFF
--- a/NXDNGateway/NXDNGateway.cpp
+++ b/NXDNGateway/NXDNGateway.cpp
@@ -38,6 +38,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <netdb.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -539,6 +540,21 @@ void CNXDNGateway::run()
 								voice->linkedTo(currentTG);
 						}
 					}
+				} else if (::memcmp(buffer + 0U, "status", 6U) == 0) {
+					std::string state = std::string("nxdn:") + ((currentAddrLen > 0) ? "conn" : "disc");
+					remoteSocket->write((unsigned char*)state.c_str(), (unsigned int)state.length(), addr, addrLen);
+				} else if (::memcmp(buffer + 0U, "host", 4U) == 0) {
+					std::string ref;
+
+					if (currentAddrLen > 0) {
+						char buffer[INET6_ADDRSTRLEN];
+						if (getnameinfo((struct sockaddr*)&currentAddr, currentAddrLen, buffer, sizeof(buffer), 0, 0, NI_NUMERICHOST | NI_NUMERICSERV) == 0) {
+							ref = std::string(buffer);
+						}
+					}
+
+					std::string host = std::string("nxdn:\"") + ((ref.length() == 0) ? "NONE" : ref) + "\"";
+					remoteSocket->write((unsigned char*)host.c_str(), (unsigned int)host.length(), addr, addrLen);
 				} else {
 					CUtils::dump("Invalid remote command received", buffer, res);
 				}


### PR DESCRIPTION
 - status: displays network connection status (n/a, conn, disc), just like DMRGateway/MMDVMHost.
 - host: display connected host, or NONE if disconnected (surrounded with double quotes).

```
root@host:~ # RemoteCommand 6075 status
Command sent: "status" to port: 6075
nxdn:conn
```

```
root@host:~ # RemoteCommand 6075 host
Command sent: "host" to port: 6075
nxdn:"66.42.93.25"
```