### PR TITLE
Fix Static on startup.

### DIFF
--- a/NXDNGateway/NXDNGateway.cpp
+++ b/NXDNGateway/NXDNGateway.cpp
@@ -336,7 +336,7 @@ void CNXDNGateway::run()
 
 						bool grp = (buffer[9U] & 0x01U) == 0x01U;
 
-						if (grp && currentTG == dstTG && (poll == false))
+						if (grp && currentTG == dstTG && !poll)
 							localNetwork->write(buffer + 10U, len - 10U);
 
 						LogMessage("Switched to reflector %u due to network activity", currentTG);


### PR DESCRIPTION
If a static talkgroup is set in the configuration file is set, some 3 poll frames are sent, but replies are ignored, hence the connection status stays disconnected, and localnetwork won't get any data also.