### PR TITLE
Change to 31264 Reflector Information

### DIFF
--- a/NXDNGateway/NXDNHosts.txt
+++ b/NXDNGateway/NXDNHosts.txt
@@ -378,7 +378,7 @@
 # 31257 NEARC
 31257	nxdn.w0jay.com	41400
 
-# 31264 XLX625 The BROniverse www.wa8bro.com
+# 31264 Dudetronics NXDN
 31264	nxdn.dudetronics.com	41400
 
 # 31266 DGTLCOM Great Lakes Digital Common Interlink (P25/DMR/YSF/NXDN/DSTAR/M17)


### PR DESCRIPTION
As per request from the owner / operator / trustee of Backyard Repeater Owners Of America (XLX625 The BROniverse WA8BRO www.wa8bro.com), Del WW2MI - as the group is not affiliated with the 31264 NXDN reflector. Please contact Del WW2MI at del@beauchamp.info with regards to this matter.