### PR TITLE
Configuration parsing bugfix

### DIFF
--- a/NXDNGateway/Conf.cpp
+++ b/NXDNGateway/Conf.cpp
@@ -154,7 +154,7 @@ bool CConf::read()
 		  char *p;
 
 		  // if value is not quoted, remove after # (to make comment)
-		  if ((p = strchr(value, '#')) != NULL)
+		  if ((p = strchr(value, '#')) != NULL && p == value)
 			  *p = '\0';
 
 		  // remove trailing tab/space


### PR DESCRIPTION
Fixes configuration bug; when "Symbol=" value contains a valid APRS literal "#", it was parsed as a comment and not honored (now has more strict checking).