### PR TITLE
Improve RemoteCommand's hosts and status.

### DIFF
--- a/NXDNGateway/NXDNGateway.cpp
+++ b/NXDNGateway/NXDNGateway.cpp
@@ -591,17 +591,39 @@ int CNXDNGateway::run()
 							else
 								m_voice->linkedTo(currentTG);
 						}
+
+						if (currentAddrLen == 0U) {
+							for (std::vector<CStaticTG>::const_iterator it = staticTGs.cbegin(); it != staticTGs.cend(); ++it)
+								LogMessage("Statically linked to reflector %u", *it);
+						}
 					}
 				} else if (::memcmp(buffer + 0U, "status", 6U) == 0) {
-					std::string state = std::string("nxdn:") + ((currentAddrLen > 0) ? "conn" : "disc");
+					std::string state = std::string("nxdn:") + (((currentAddrLen > 0) || !staticTGs.empty()) ? "conn" : "disc");
 					remoteSocket->write((unsigned char*)state.c_str(), (unsigned int)state.length(), addr, addrLen);
 				} else if (::memcmp(buffer + 0U, "host", 4U) == 0) {
 					std::string ref;
+					char buffer[INET6_ADDRSTRLEN];
+
+					// Concat Statics, if defined.
+					for (std::vector<CStaticTG>::const_iterator it = staticTGs.cbegin(); it != staticTGs.cend(); ++it) {
+
+						// CurrentAddr is not in Static list
+						if ((currentAddrLen == 0U) || ((currentAddrLen > 0U) && !CUDPSocket::match(currentAddr, (*it).m_addr))) {
+							if (ref.length() > 0)
+								ref += ",";
+
+							if (::getnameinfo((struct sockaddr*)&(*it).m_addr, (*it).m_addrLen, buffer, sizeof(buffer), 0, 0, NI_NUMERICHOST | NI_NUMERICSERV) == 0)
+								ref += std::string(buffer);
+						}
+					}
 
 					if (currentAddrLen > 0U) {
-						char buffer[INET6_ADDRSTRLEN];
-						if (::getnameinfo((struct sockaddr*)&currentAddr, currentAddrLen, buffer, sizeof(buffer), 0, 0, NI_NUMERICHOST | NI_NUMERICSERV) == 0)
-							ref = std::string(buffer);
+						if (::getnameinfo((struct sockaddr*)&currentAddr, currentAddrLen, buffer, sizeof(buffer), 0, 0, NI_NUMERICHOST | NI_NUMERICSERV) == 0) {
+							if (ref.length() > 0)
+								ref += ",";
+
+							ref += std::string(buffer);
+						}
 					}
 
 					std::string host = std::string("nxdn:\"") + ((ref.length() == 0) ? "NONE" : ref) + "\"";

--- a/NXDNGateway/UDPSocket.cpp
+++ b/NXDNGateway/UDPSocket.cpp
@@ -94,7 +94,7 @@ int CUDPSocket::lookup(const std::string& hostname, unsigned short port, sockadd
 	/* Port is always digits, no needs to lookup service */
 	hints.ai_flags |= AI_NUMERICSERV;
 
-	int err = ::getaddrinfo(hostname.empty() ? nullptr : hostname.c_str(), portstr.c_str(), &hints, &res);
+	int err = ::getaddrinfo(hostname.empty() ? NULL : hostname.c_str(), portstr.c_str(), &hints, &res);
 	if (err != 0) {
 		sockaddr_in* paddr = (sockaddr_in*)&addr;
 		::memset(paddr, 0x00U, address_length = sizeof(sockaddr_in));

--- a/NXDNGateway/Version.h
+++ b/NXDNGateway/Version.h
@@ -19,6 +19,6 @@
 #if !defined(VERSION_H)
 #define	VERSION_H
 
-const char* VERSION = "20250319";
+const char* VERSION = "20250607";
 
 #endif

--- a/NXDNParrot/UDPSocket.cpp
+++ b/NXDNParrot/UDPSocket.cpp
@@ -94,7 +94,7 @@ int CUDPSocket::lookup(const std::string& hostname, unsigned short port, sockadd
 	/* Port is always digits, no needs to lookup service */
 	hints.ai_flags |= AI_NUMERICSERV;
 
-	int err = ::getaddrinfo(hostname.empty() ? nullptr : hostname.c_str(), portstr.c_str(), &hints, &res);
+	int err = ::getaddrinfo(hostname.empty() ? NULL : hostname.c_str(), portstr.c_str(), &hints, &res);
 	if (err != 0) {
 		sockaddr_in* paddr = (sockaddr_in*)&addr;
 		::memset(paddr, 0x00U, address_length = sizeof(sockaddr_in));

--- a/NXDNParrot/Version.h
+++ b/NXDNParrot/Version.h
@@ -19,6 +19,6 @@
 #if !defined(VERSION_H)
 #define	VERSION_H
 
-const char* VERSION = "20250319";
+const char* VERSION = "20250607";
 
 #endif


### PR DESCRIPTION
NXDNGateway:
  - Handle Static TGs when reporting RemoteCommand's hosts and status.

NXDNGateway and NXDNParrot:
  - Fix nullptr instead of NULL argument usage in getaddrinfo().
  - Bump version.